### PR TITLE
fix(sec): upgrade org.springframework.boot:spring-boot-autoconfigure to 3.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <protostuff.version>1.7.2</protostuff.version>
         <jsckson.version>2.9.9</jsckson.version>
 
-        <spring.boot.version>2.1.1.RELEASE</spring.boot.version>
+        <spring.boot.version>3.0.7</spring.boot.version>
 
     </properties>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework.boot:spring-boot-autoconfigure 2.1.1.RELEASE
- [CVE-2023-20883](https://www.oscs1024.com/hd/CVE-2023-20883)


### What did I do？
Upgrade org.springframework.boot:spring-boot-autoconfigure from 2.1.1.RELEASE to 3.0.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS