### PR TITLE
fix(sec): upgrade org.springframework:spring-core to 5.3.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 
         <caffeine.version>2.6.2</caffeine.version>
         <lettuce.version>5.1.3.RELEASE</lettuce.version>
-        <spring.version>5.1.3.RELEASE</spring.version>
+        <spring.version>6.0.7</spring.version>
         <slf4j.version>1.7.25</slf4j.version>
         <fastjson.version>1.2.78</fastjson.version>
         <aspectj.version>1.9.2</aspectj.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework:spring-core 5.1.3.RELEASE
- [CVE-2021-22060](https://www.oscs1024.com/hd/CVE-2021-22060)


### What did I do？
Upgrade org.springframework:spring-core from 5.1.3.RELEASE to 5.3.14 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS