### PR TITLE
feat: 当前core中部分日志输出依赖fastjson进行序列化，当序列化非FastJson实现类时，会导致报错，缺少fastjson…

### DIFF
--- a/layering-cache-core/src/main/java/com/github/xiaolyuh/redis/clinet/ClusterRedisClient.java
+++ b/layering-cache-core/src/main/java/com/github/xiaolyuh/redis/clinet/ClusterRedisClient.java
@@ -1,6 +1,5 @@
 package com.github.xiaolyuh.redis.clinet;
 
-import com.alibaba.fastjson.JSON;
 import com.github.xiaolyuh.listener.RedisMessageListener;
 import com.github.xiaolyuh.redis.command.TencentScan;
 import com.github.xiaolyuh.redis.serializer.JdkRedisSerializer;
@@ -80,7 +79,7 @@ public class ClusterRedisClient implements RedisClient {
     private final StatefulRedisPubSubConnection<String, String> pubSubConnection;
 
     public ClusterRedisClient(RedisProperties properties) {
-        logger.info("layering-cache redis配置" + JSON.toJSONString(properties));
+        logger.info("layering-cache redis配置 : {}", properties);
 
         String cluster = properties.getCluster();
         String[] parts = cluster.split("\\,");

--- a/layering-cache-core/src/main/java/com/github/xiaolyuh/redis/clinet/SentinelRedisClient.java
+++ b/layering-cache-core/src/main/java/com/github/xiaolyuh/redis/clinet/SentinelRedisClient.java
@@ -1,6 +1,5 @@
 package com.github.xiaolyuh.redis.clinet;
 
-import com.alibaba.fastjson.JSON;
 import com.github.xiaolyuh.listener.RedisMessageListener;
 import com.github.xiaolyuh.redis.serializer.JdkRedisSerializer;
 import com.github.xiaolyuh.redis.serializer.RedisSerializer;
@@ -73,7 +72,7 @@ public class SentinelRedisClient implements RedisClient {
         }
         RedisURI redisURI = builder.build();
 
-        logger.info("layering-cache redis配置 {}", JSON.toJSONString(properties));
+        logger.info("layering-cache redis配置 : {}", properties);
         io.lettuce.core.RedisClient client = io.lettuce.core.RedisClient.create(redisURI);
         client.setOptions(ClientOptions.builder()
                 .autoReconnect(true)

--- a/layering-cache-core/src/main/java/com/github/xiaolyuh/redis/clinet/SingleRedisClient.java
+++ b/layering-cache-core/src/main/java/com/github/xiaolyuh/redis/clinet/SingleRedisClient.java
@@ -1,6 +1,5 @@
 package com.github.xiaolyuh.redis.clinet;
 
-import com.alibaba.fastjson.JSON;
 import com.github.xiaolyuh.listener.RedisMessageListener;
 import com.github.xiaolyuh.redis.serializer.JdkRedisSerializer;
 import com.github.xiaolyuh.redis.serializer.RedisSerializer;
@@ -65,7 +64,7 @@ public class SingleRedisClient implements RedisClient {
             redisURI.setPassword(properties.getPassword());
         }
 
-        logger.info("layering-cache redis配置" + JSON.toJSONString(properties));
+        logger.info("layering-cache redis配置 : {}", properties);
         io.lettuce.core.RedisClient client = io.lettuce.core.RedisClient.create(redisURI);
         client.setOptions(ClientOptions.builder()
                 .autoReconnect(true)


### PR DESCRIPTION
当前core中部分日志输出依赖fastjson进行序列化，当序列化非FastJson实现类时，会导致报错，缺少fastjson依赖。旨在支持解除对fastjson的强制依赖。